### PR TITLE
Custom labels

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -501,7 +501,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			template.Spec.SecurityContext = podSecurityContext
 		}
 		template.Spec.Containers[0].Ports = ports
-		template.ObjectMeta.Labels = transformer.ConfigLabels(name)
+		template.ObjectMeta.Labels = transformer.ConfigLabelsWithService(name, service)
 
 		// Configure the container restart policy.
 		switch service.Restart {

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -182,13 +182,13 @@ func (k *Kubernetes) InitRC(name string, service kobject.ServiceConfig, replicas
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: int32(replicas),
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Labels: transformer.ConfigLabels(name),
+					Labels: transformer.ConfigLabelsWithService(name, service),
 				},
 				Spec: k.InitPodSpec(name, service.Image),
 			},
@@ -206,10 +206,10 @@ func (k *Kubernetes) InitSvc(name string, service kobject.ServiceConfig) *api.Se
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: api.ServiceSpec{
-			Selector: transformer.ConfigLabels(name),
+			Selector: transformer.ConfigLabelsWithService(name, service),
 		},
 	}
 	return svc
@@ -235,7 +235,7 @@ func (k *Kubernetes) InitConfigMapForEnv(name string, service kobject.ServiceCon
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name + "-" + envName,
-			Labels: transformer.ConfigLabels(name + "-" + envName),
+			Labels: transformer.ConfigLabelsWithService(name + "-" + envName, service),
 		},
 		Data: envs,
 	}
@@ -266,7 +266,7 @@ func (k *Kubernetes) InitConfigMapFromFile(name string, service kobject.ServiceC
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   FormatFileName(configMapName),
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Data: dataMap,
 	}
@@ -290,7 +290,7 @@ func (k *Kubernetes) InitD(name string, service kobject.ServiceConfig, replicas 
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: extensions.DeploymentSpec{
 			Replicas: int32(replicas),
@@ -311,7 +311,7 @@ func (k *Kubernetes) InitDS(name string, service kobject.ServiceConfig) *extensi
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: extensions.DaemonSetSpec{
 			Template: api.PodTemplateSpec{
@@ -331,7 +331,7 @@ func (k *Kubernetes) initIngress(name string, service kobject.ServiceConfig, por
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: extensions.IngressSpec{
 			Rules: []extensions.IngressRule{
@@ -792,7 +792,7 @@ func (k *Kubernetes) InitPod(name string, service kobject.ServiceConfig) *api.Po
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: k.InitPodSpec(name, service.Image),
 	}

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -304,8 +304,8 @@ func TestKomposeConvert(t *testing.T) {
 
 		var foundSVC, foundD, foundDS, foundRC, foundDC bool
 		name := "app"
-		labels := transformer.ConfigLabels(name)
 		config := test.komposeObject.ServiceConfigs[name]
+		labels := transformer.ConfigLabelsWithService(name, config)
 		// Check results
 		for _, obj := range objs {
 			if svc, ok := obj.(*api.Service); ok {

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -104,7 +104,7 @@ func (o *OpenShift) initImageStream(name string, service kobject.ServiceConfig, 
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: imageapi.ImageStreamSpec{
 			Tags: tags,
@@ -138,7 +138,7 @@ func initBuildConfig(name string, service kobject.ServiceConfig, repo string, br
 
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: buildapi.BuildConfigSpec{
 			Triggers: []buildapi.BuildTriggerPolicy{
@@ -197,15 +197,15 @@ func (o *OpenShift) initDeploymentConfig(name string, service kobject.ServiceCon
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: int32(replicas),
-			Selector: transformer.ConfigLabels(name),
+			Selector: transformer.ConfigLabelsWithService(name, service),
 			//UniqueLabelKey: p.Name,
 			Template: &kapi.PodTemplateSpec{
 				ObjectMeta: kapi.ObjectMeta{
-					Labels: transformer.ConfigLabels(name),
+					Labels: transformer.ConfigLabelsWithService(name, service),
 				},
 				Spec: podSpec,
 			},
@@ -240,7 +240,7 @@ func (o *OpenShift) initRoute(name string, service kobject.ServiceConfig, port i
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
-			Labels: transformer.ConfigLabels(name),
+			Labels: transformer.ConfigLabelsWithService(name, service),
 		},
 		Spec: routeapi.RouteSpec{
 			Port: &routeapi.RoutePort{

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -113,7 +113,13 @@ func ConfigLabels(name string) map[string]string {
 }
 
 func ConfigLabelsWithService(name string, service kobject.ServiceConfig) map[string]string {
-	return map[string]string{Selector: name}
+	labels := map[string]string{}
+	for key, value := range service.Annotations {
+		labels[key] = value
+	}
+	labels["Selector"] = name
+
+	return labels
 }
 
 // ConfigAnnotations configures annotations

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -112,6 +112,10 @@ func ConfigLabels(name string) map[string]string {
 	return map[string]string{Selector: name}
 }
 
+func ConfigLabelsWithService(name string, service kobject.ServiceConfig) map[string]string {
+	return map[string]string{Selector: name}
+}
+
 // ConfigAnnotations configures annotations
 func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 	annotations := map[string]string{}

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -115,7 +115,9 @@ func ConfigLabels(name string) map[string]string {
 func ConfigLabelsWithService(name string, service kobject.ServiceConfig) map[string]string {
 	labels := map[string]string{}
 	for key, value := range service.Annotations {
-		labels[key] = value
+		if strings.HasPrefix(key, "kompose.label.") {
+			labels[key[14:]] = value
+		}
 	}
 	labels["Selector"] = name
 


### PR DESCRIPTION
Add support for labeling Kubernetes resources via labels starting with `kompose.label`.